### PR TITLE
Create print_summary command

### DIFF
--- a/Python/Actions/ProjectActions/print_summary.py
+++ b/Python/Actions/ProjectActions/print_summary.py
@@ -1,0 +1,34 @@
+"""
+An action that will print a summary about the current dictionary.
+
+File: print_summary.py
+"""
+
+import qprompt
+
+import dictionary
+
+from Actions import menu_actions
+
+
+class PrintSummaryAction(menu_actions.BaseAction):
+    """An action that will print the summary of the current dictionary."""
+
+    COMMAND_NAME = "Print Summary"
+    HELP_TEXT = "Print a summary of all the words in the dictionary."
+
+    def run_command(self, menu_context):
+        """Run the command that will print a summary of the dictionary.
+
+        :menu_context: The context of the menu.
+
+        """
+        dictionary = menu_context.get("dictionary", None)
+        if dictionary is None:
+            print("Menu does not have a dictionary")
+            qprompt.pause()
+            return
+
+        dictionary.print_summary()
+
+        qprompt.pause()

--- a/Python/dictionary.py
+++ b/Python/dictionary.py
@@ -235,3 +235,13 @@ class Dictionary():
                 words_from_level.append(current_word)
 
         return words_from_level
+
+    def print_summary(self):
+        words_above_level_one = 0
+        for current_level in range(5):
+            current_number_of_words = len(self.get_words_from_level(current_level))
+            print(f"{current_number_of_words} words from level {current_level}")
+            if current_level > 0:
+                words_above_level_one += current_number_of_words
+        print(f"There are {words_above_level_one} words above level one")
+        print(f"There are {len(self.words)} words in the dictionary.")

--- a/Python/main.py
+++ b/Python/main.py
@@ -18,12 +18,14 @@ from Actions.ProjectActions import extend_dictionary
 from Actions.ProjectActions import dictionary_learned_translate
 from Actions.ProjectActions import dictionary_native_translate
 from Actions.ProjectActions import run_test
+from Actions.ProjectActions import print_summary
 
 ALL_AVAILABLE_COMMANDS = [
     load_dictionary.LoadDictionaryAction,
     add_dictionary.AddDictionaryAction,
     save_dictionary.SaveDictionaryAction,
     print_dictionary.PrintDictionaryAction,
+    print_summary.PrintSummaryAction,
     run_test.RunTestAction,
     add_new_word.AddNewWordAction,
     add_new_word.BulkAddNewWordAction,


### PR DESCRIPTION
This new command lets the user print a summary of the current dictionary
to the screen. The summary includes information about the current
dictionary (the total number of words, words in each level and so on).

This commit fixes #43