### PR TITLE
Add command to remove words from dictionary

### DIFF
--- a/Python/Actions/ProjectActions/delete_word.py
+++ b/Python/Actions/ProjectActions/delete_word.py
@@ -1,0 +1,45 @@
+"""
+An action that will delete a word from the dictionary.
+
+File: delete_word.py
+"""
+
+import consolemenu
+import qprompt
+
+from Actions import menu_actions
+from Utils import safe_ask
+
+
+class DeleteWordAction(menu_actions.BaseAction):
+    """An action that will delete a word from the dictionary."""
+
+    COMMAND_NAME = "Delete Word"
+    HELP_TEXT = "Delete a word from the dictionary."
+
+    def run_command(self, menu_context):
+        """Run the command that will delete a word from the dictionary.
+
+        :menu_context: The context of the menu to add the dictionary to.
+        """
+        if menu_context.get("dictionary", None) is None:
+            print("Menu does not have a dictionary")
+            qprompt.pause()
+            return
+
+        dictionary = menu_context["dictionary"]
+
+        word_index_to_remove = safe_ask.safe_ask(
+            qprompt.ask_int,
+            "Insert the index of the word to remove")
+
+        word_to_remove = dictionary.get_word_by_index(word_index_to_remove)
+        if qprompt.ask_yesno(
+            f"Do you want to remove the word \"{word_to_remove}?\"",
+            dft=False):
+            dictionary.delete_word(word_index_to_remove)
+            print("Word removed")
+        else:
+            print("Word not removed")
+
+        qprompt.pause()

--- a/Python/dictionary.py
+++ b/Python/dictionary.py
@@ -245,3 +245,20 @@ class Dictionary():
                 words_above_level_one += current_number_of_words
         print(f"There are {words_above_level_one} words above level one")
         print(f"There are {len(self.words)} words in the dictionary.")
+
+    def delete_word(self, word_index):
+        """Delete a word from the dictionary.
+
+        :word_index: The index of the word to delete from the dictionary.
+
+        """
+        self.words.pop(word_index)
+
+    def get_word_by_index(self, word_index):
+        """Get the word in the given index.
+
+        :word_index: The index of the word to get.
+
+        """
+        return self.words[word_index]
+

--- a/Python/main.py
+++ b/Python/main.py
@@ -19,6 +19,7 @@ from Actions.ProjectActions import dictionary_learned_translate
 from Actions.ProjectActions import dictionary_native_translate
 from Actions.ProjectActions import run_test
 from Actions.ProjectActions import print_summary
+from Actions.ProjectActions import delete_word
 
 ALL_AVAILABLE_COMMANDS = [
     load_dictionary.LoadDictionaryAction,
@@ -33,6 +34,7 @@ ALL_AVAILABLE_COMMANDS = [
     extend_dictionary.ExtendDictionaryAction,
     dictionary_learned_translate.TranlateToLearnedDictionaryAction,
     dictionary_native_translate.TranlateToNativeDictionaryAction,
+    delete_word.DeleteWordAction,
     help_action.HelpAction,
 ]
 


### PR DESCRIPTION
Add a new command to the project, that removes a given word from the
dictionary. This command can be used in order to remove words that were
added to the dictionary by mistake, or that contains errors.

The current command removes the words according to the index of the word
in the dictionary. This is done this way because this is the easiest way
to remove the words, it can be changed in the future to support better
removing.

This commit fixes #13